### PR TITLE
adding android:exported at service in the AndroidManifest

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:theme="@style/Theme.SendNotifications">
 
         <service
-            android:name=".MyFirebaseMessagingService">
+            android:name=".MyFirebaseMessagingService"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT"/>
             </intent-filter>


### PR DESCRIPTION
Since Android 12 it is mandatory so it can cause errors when building the application. "false" is the default value when there are no intent filters, but we are using an intent-filter there!