### PR TITLE
Updating to stable versions and exclude META-INF

### DIFF
--- a/gradle_app/build.gradle
+++ b/gradle_app/build.gradle
@@ -30,6 +30,10 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
+    packagingOptions {
+        exclude 'META-INF/DEPENDENCIES'
+    }
 }
 
 apply plugin: 'com.android.application'
@@ -49,8 +53,8 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
 
-    implementation platform('com.google.firebase:firebase-bom:26.6.0')
-    implementation 'com.google.firebase:firebase-messaging-ktx'
-    implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation platform('com.google.firebase:firebase-bom:29.2.0')
+    implementation 'com.google.firebase:firebase-messaging-ktx:23.0.1'
+    implementation 'com.google.firebase:firebase-analytics-ktx:20.1.0'
 
 }


### PR DESCRIPTION
The META-INF exclusion is to prevent to have two meta-inf/dependencies files from different places. I had this error, it can be for the gradle version that I used.